### PR TITLE
Remove undent call on EOS

### DIFF
--- a/elasticsearch090.rb
+++ b/elasticsearch090.rb
@@ -59,7 +59,7 @@ class Elasticsearch090 < Formula
     (var/"lib/elasticsearch/plugins").mkpath
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<-EOS
     Data:    #{var}/elasticsearch/#{cluster_name}/
     Logs:    #{var}/log/elasticsearch/#{cluster_name}.log
     Plugins: #{var}/lib/elasticsearch/plugins/
@@ -68,7 +68,7 @@ class Elasticsearch090 < Formula
 
   plist_options :manual => "elasticsearch --config=#{HOMEBREW_PREFIX}/opt/elasticsearch/config/elasticsearch.yml"
 
-  def plist; <<-EOS.undent
+  def plist; <<-EOS
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
       <plist version="1.0">

--- a/elasticsearch14.rb
+++ b/elasticsearch14.rb
@@ -74,7 +74,7 @@ class Elasticsearch14 < Formula
     ln_s etc/"elasticsearch", prefix/"config"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<-EOS
     Data:    #{var}/elasticsearch/#{cluster_name}/
     Logs:    #{var}/log/elasticsearch/#{cluster_name}.log
     Plugins: #{var}/lib/elasticsearch/plugins/
@@ -84,7 +84,7 @@ class Elasticsearch14 < Formula
 
   plist_options :manual => "elasticsearch --config=#{HOMEBREW_PREFIX}/opt/elasticsearch14/config/elasticsearch.yml"
 
-  def plist; <<-EOS.undent
+  def plist; <<-EOS
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
       <plist version="1.0">

--- a/elasticsearch15.rb
+++ b/elasticsearch15.rb
@@ -91,7 +91,7 @@ class Elasticsearch15 < Formula
     ln_s etc/"elasticsearch", prefix/"config"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<-EOS
     Data:    #{var}/elasticsearch/#{cluster_name}/
     Logs:    #{var}/log/elasticsearch/#{cluster_name}.log
     Plugins: #{var}/lib/elasticsearch/plugins/
@@ -101,7 +101,7 @@ class Elasticsearch15 < Formula
 
   plist_options :manual => "elasticsearch --config=#{HOMEBREW_PREFIX}/opt/elasticsearch/config/elasticsearch.yml"
 
-  def plist; <<-EOS.undent
+  def plist; <<-EOS
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
       <plist version="1.0">

--- a/mongodb268.rb
+++ b/mongodb268.rb
@@ -69,7 +69,7 @@ class Mongodb268 < Formula
     (var+"log/mongodb").mkpath
   end
 
-  def mongodb_conf; <<-EOS.undent
+  def mongodb_conf; <<-EOS
     systemLog:
       destination: file
       path: #{var}/log/mongodb/mongo.log
@@ -83,7 +83,7 @@ class Mongodb268 < Formula
 
   plist_options :manual => "mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
 
-  def plist; <<-EOS.undent
+  def plist; <<-EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">

--- a/mongodb307.rb
+++ b/mongodb307.rb
@@ -103,7 +103,7 @@ class Mongodb307 < Formula
     (var+"log/mongodb").mkpath
   end
 
-  def mongodb_conf; <<-EOS.undent
+  def mongodb_conf; <<-EOS
     systemLog:
       destination: file
       path: #{var}/log/mongodb/mongo.log
@@ -117,7 +117,7 @@ class Mongodb307 < Formula
 
   plist_options :manual => "mongod --config #{HOMEBREW_PREFIX}/etc/mongod.conf"
 
-  def plist; <<-EOS.undent
+  def plist; <<-EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">


### PR DESCRIPTION
The Dev team here at the bouqs hit this blocking error when trying to install deps on OS 10.13.x with brew 1.6.0.  The team here changed the .rb files in `/usr/local/Cellar` to get this to work.    

Below is the error that is thrown:
 
```bash
Error: Calling <<-EOS.undent is disabled!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/weblinc/homebrew-formulas/elasticsearch15.rb:133:in `plist'
Please report this to the weblinc/formulas tap!
Or, even better, submit a PR to fix it!
```

 Removing the `undent` call fixes the error.
